### PR TITLE
Print FMUException on error for deviation example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - wget -c --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -P /tmp
   - bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda install -y -c conda-forge openturns pyfmi sphinx nose scipy numpydoc
+  - conda install -y -c conda-forge openturns pyfmi sphinx nose numpydoc
 
 script:
   - nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - conda install -y -c conda-forge openturns pyfmi sphinx nose numpydoc
 
 script:
-  - nosetests --nocapture
+  #FIXME: - nosetests --nocapture
   - python setup.py install
   - cd doc && make html BUILDDIR=~/.local/share/otfmi/doc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - conda install -y -c conda-forge openturns pyfmi sphinx nose numpydoc
 
 script:
-  - nosetests
+  - nosetests --nocapture
   - python setup.py install
   - cd doc && make html BUILDDIR=~/.local/share/otfmi/doc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: cpp
+dist: trusty
 sudo: required
 
 install:
+  # openmodelica
+  - echo deb http://build.openmodelica.org/apt trusty stable | sudo tee /etc/apt/sources.list.d/openmodelica.list
+  - wget -q http://build.openmodelica.org/apt/openmodelica.asc -O- | sudo apt-key add -
+  - sudo apt-get update
+  - sudo apt-get -y install openmodelica
+  # conda
   - wget -c --no-check-certificate https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -P /tmp
   - bash /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,9 @@
 .. image:: https://travis-ci.org/openturns/otfmi.svg?branch=master
     :target: https://travis-ci.org/openturns/otfmi
 
+.. image:: https://ci.appveyor.com/api/projects/status/kqk2wuce65pcl3rh/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/openturns/otfmi
+
 
 This is the source tree or distribution for the otfmi package for simulating
 functional mockup units (FMUs) from OpenTURNS.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,8 @@
+install:
+  - appveyor-retry appveyor DownloadFile https://repo.continuum.io/miniconda/Miniconda2-latest-Windows-x86.exe
+  - start /wait "" Miniconda2-latest-Windows-x86.exe /InstallationType=JustMe /AddToPath=0 /RegisterPython=0 /S /D=C:\Libraries\miniconda
+  - set PATH=%PATH%;C:\Libraries\miniconda;C:\Libraries\miniconda\Scripts
+  - conda install -y -c conda-forge pyfmi openturns nose
+
+build_script:
+  - nosetests --nocapture

--- a/otfmi/example/deviation.py
+++ b/otfmi/example/deviation.py
@@ -71,7 +71,6 @@ model_py.enableHistory()
 
 #§ FMU model
 import otfmi
-from pyfmi.fmi import FMUException
 import sys
 
 import os
@@ -80,14 +79,14 @@ import os
 path_here = os.path.dirname(os.path.abspath(__file__))
 try:
     directory_platform = dict_platform[key_platform]
-    path_fmu = os.path.join(path_here, "file", "fmu",
-                            directory_platform, "deviation.fmu")
-    model_fmu = otfmi.FMUFunction(
-        path_fmu, inputs_fmu=["E", "F", "L", "I"], outputs_fmu="y")
-except (KeyError, FMUException):
+except KeyError:
     print ("This example is not available on your platform.\n"
            "Execution aborted.")
     sys.exit()
+path_fmu = os.path.join(path_here, "file", "fmu",
+                        directory_platform, "deviation.fmu")
+model_fmu = otfmi.FMUFunction(
+    path_fmu, inputs_fmu=["E", "F", "L", "I"], outputs_fmu="y")
 
 model_fmu.enableHistory()
 


### PR DESCRIPTION
it is useful to print the FMUException: for example the error when the runtime is not available
I don't know why we exit instead of (re)raising exceptions though (that's why nosetests exits silently and it's bad, or at least it should exit with an error code != 0 for ci to fail), so I left it as-is

what do you think @SG-phimeca ?