### PR TITLE
Stop useless move of wrapper.c

### DIFF
--- a/otfmi/function_exporter.py
+++ b/otfmi/function_exporter.py
@@ -332,8 +332,7 @@ class FunctionExporter(object):
                 libname = "cwrapper.lib"
             else:
                 libname = "libcwrapper.a"
-            list_file = [
-                "function.xml", libname, className + extension]
+            list_file = [libname, className + extension]
             for file in list_file:
                 shutil.move(os.path.join(self.workdir, file),
                             os.path.join(dirName, file))

--- a/otfmi/function_exporter.py
+++ b/otfmi/function_exporter.py
@@ -333,8 +333,7 @@ class FunctionExporter(object):
             else:
                 libname = "libcwrapper.a"
             list_file = [
-                "function.xml", libname, "wrapper.c",
-                className + extension]
+                "function.xml", libname, className + extension]
             for file in list_file:
                 shutil.move(os.path.join(self.workdir, file),
                             os.path.join(dirName, file))


### PR DESCRIPTION
The metamodel wrapper, temporary files and binaries are created in a temporary folder.
To make the user's life easier, the metamodel wrapper and binaries are copied in a folder designated by the user.

Former : wrapper.c and function.xml are moved in the user's folder, but the files are useless for simulation.
Current : wrapper.c and function.xml are not moved from the temporary folder anymore.