### PR TITLE
Removed FMU files from the package data

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,5 @@
+- Removed demo FMU files from the package.
+
 2021-09-15 - release 0.14
 - fix memory leak
 

--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ classical distutils procedure. From the main folder, run the following command:
     python setup.py install
 
 On windows, it is possible to avoid resorting to command line interface by using the
-installer program otfmi-X.X.win32.exe ( X.X is the version number).
+installer program otfmi-X.X.win32.exe (where X.X is the version number).
 
 Manual removal
 --------------
@@ -67,6 +67,8 @@ See the “Project documentation” [PROJECTDOC]_ for information about the modu
 
 Example scripts are given in the 'example' folder in the source tree.
 
+Example FMU files are provided at [FMUDEMOS]_.
+
 License
 =======
 
@@ -78,3 +80,4 @@ References
 .. [ANACONDA] Anaconda, Python distribution. url: http://continuum.io/downloads
 .. [USERDOC] Girard, Sylvain (2017). otfmi: simulate FMUs from OpenTURNS: User documentation. Tech. rep. RT-PMFRE-00997-003. EDF. url: https://openturns.github.io/openturns/papers/otfmi_user_documentation.pdf
 .. [PROJECTDOC] Girard, Sylvain (2017). otfmi: simulate FMUs from OpenTURNS: Project documentation. Tech. rep. RT-PMFRE-00997-002. EDF. url: https://openturns.github.io/openturns/papers/otfmi_project_documentation.pdf
+.. [FMUDEMOS] FMU demonstration files. https://github.com/openturns/otfmi/tree/master/otfmi/example/file/fmu

--- a/setup.py
+++ b/setup.py
@@ -82,9 +82,7 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-        "otfmi": ["example/file/fmu/linux64/*.fmu",
-                  "example/file/fmu/win32/*.fmu",
-                  "example/file/initialization_script/*.mos"]
+        "otfmi": ["example/file/initialization_script/*.mos"]
     },
 
     # Although 'package_data' is the preferred approach, in some case you may


### PR DESCRIPTION
When we install otfmi on a Win64 machine using conda, the example\file\fmu\win64 directory is not available. This makes the package less easy to use on a Win64 machine, because no usable fmu is available right out of the box. This PR aims at providing the fmu files within the conda package.
