### PR TITLE
Fix FMUs' copy for manual installation of OTFMI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,8 +82,10 @@ setup(
     # installed, specify them here.  If using Python 2.6 or less, then these
     # have to be included in MANIFEST.in as well.
     package_data={
-        "otfmi": ["example/file/initialization_script/*",
-                  "example/fmu/*"]
+        "otfmi": ["example/file/initialization_script/*.mos",
+                  "example/file/fmu/linux64/*.fmu",
+                  "example/file/fmu/win32/*.fmu",
+                  "example/file/fmu/win64/*.fmu"]
     },
 
     # Although 'package_data' is the preferred approach, in some case you may


### PR DESCRIPTION
**Before** 
When using `python setup.py install`, the FMUs were not copied into the .egg.
Hence the following code:
```
import otfmi.example.utility
path_fmu = otfmi.example.utility.get_path_fmu("deviation")
model = otfmi.fmi.load_fmu(path_fmu)
```
raised following error: `FMUException: Could not locate the FMU in the specified directory.`

**Now**
FMUs are copied in the .egg, enabling automatic import in code.

