### PR TITLE
Simulate on the entire mesh specified by the user.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,7 @@ otfmi/example/file/initialization_script/debug_deviation.mos
 otfmi/example/status
 otfmi/example/success
 test/deviationpoutre_log.txt
+test/deviationl_log.txt
+test/epid_log.txt
+test/epid_result.txt
 tmp.org

--- a/otfmi/otfmi.py
+++ b/otfmi/otfmi.py
@@ -448,9 +448,10 @@ class OpenTURNSFMUPointToFieldFunction(ot.OpenTURNSPythonPointToFieldFunction):
 
         self._set_inputs_fmu(inputs_fmu)
         self._set_outputs_fmu(outputs_fmu)
+        self.mesh = mesh
 
-        super(OpenTURNSFMUPointToFieldFunction, self).__init__(len(self.inputs_fmu), mesh,
-                                                               len(self.outputs_fmu))
+        super(OpenTURNSFMUPointToFieldFunction, self).__init__(
+            len(self.inputs_fmu), mesh, len(self.outputs_fmu))
         self._set_inputs(inputs)
         self._set_outputs(outputs)
 
@@ -551,8 +552,18 @@ class OpenTURNSFMUPointToFieldFunction(ot.OpenTURNSPythonPointToFieldFunction):
         See the 'simulate' method for additional keyword arguments.
 
         """
+        final_time = self.adapt_final_time()
+        return self.simulate(value_input=value_input, final_time=final_time,
+           **kwargs)
 
-        return self.simulate(value_input=value_input, **kwargs)
+    def adapt_final_time(self):
+        """Adapt FMU stop time to the mesh given by the user.
+
+        """
+        meshSample = self.mesh.getVertices()
+        final_time = meshSample.getMax()[0]
+        return final_time
+
 
     def load_fmu(self, path_fmu, kind=None, **kwargs):
         """Load an FMU.

--- a/test/test_epid.py
+++ b/test/test_epid.py
@@ -30,7 +30,6 @@ def simulate_with_pyfmi(path_fmu):
     infected_column = list_variable.index("infected") + 1
     # +1 stands for time column, inserted as first in the data matrix
     list_last_infected_value = check_result.data_matrix[infected_column][-5:-1]
-    print(list_last_infected_value)
     return list_last_infected_value
 
 
@@ -71,17 +70,35 @@ class TestEpid(unittest.TestCase):
         assert y[0] > min(list_last_infected_value)
 
     def test_timevariant_function(self):
-        """Check that FMUPointToFieldFunction returns a trajectory."""
+        """Check that FMUPointToFieldFunction returns a trajectory.
+        """
         mesh = ot.RegularGrid(0.0, 0.5, 100)
-        model_fmu = otfmi.FMUPointToFieldFunction(
+        function = otfmi.FMUPointToFieldFunction(
             mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],
             outputs_fmu=['infected'])
-        y = model_fmu(input_value)
-        print('y=', y)
+        y = function(input_value)
         assert y.getMax()[0] - y.getMin()[0] > 0
         assert m.fabs(y[0][0] - 1.0) < 1e-2, "wrong value"
+
+    def test_set_final_time(self):
+        """Check the variation of model outputs after the default FMU stop time.
+        """
+        model = pyfmi.load_fmu(self.path_fmu)
+        default_stop_time = model.get_default_experiment_stop_time()
+        last_index = round(default_stop_time)
+        interval = 13
+        mesh = ot.RegularGrid(0.0, 1., last_index + interval)
+        function = otfmi.OpenTURNSFMUPointToFieldFunction(
+            mesh,
+            self.path_fmu,
+            inputs_fmu=['infection_rate', 'healing_rate'],
+            outputs_fmu=['infected'])
+        y = function(input_value)
+        post_stop_sample = y.select(
+            list(range(last_index, last_index + interval)))
+        assert post_stop_sample.getMin()[0] < post_stop_sample.getMax()[0]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Context : the user gives a mesh as input of OpenTURNSFMUPointToFieldFunction. The FMU output is interpolated on this mesh.

Issue : when the mesh last value is larger than the FMU default simulation time, OpenTURNSFMUPointToFunction output is filled with the FMU last value. The output is thus evolving from time=0 to time=FMU_default_simulation_time; then it is constant.

Improvement : the mesh last value now specifies the FMU simulation time.