### PR TITLE
Manage FMU simulation times

### DIFF
--- a/otfmi/otfmi.py
+++ b/otfmi/otfmi.py
@@ -47,7 +47,12 @@ class FMUFunction(ot.Function):
     initialization_script : str (optional)
         Path to the initialization script.
 
-    kind : str, one of "ME" (model exchange) or "CS" (co-simulation)
+    final_time : float
+        The output variables value is collected at t=final_time and returned by
+        FMUFunction.
+
+    kind : str, one of "ME" (model exchange) or "CS" 
+        (co-simulation)
         Select a kind of FMU if both are available.
         Note:
         Contrary to pyfmi, the default here is "CS" (co-simulation). The
@@ -103,6 +108,10 @@ class OpenTURNSFMUFunction(ot.OpenTURNSPythonFunction):
 
     initialization_script : str (optional)
         Path to the initialization script.
+
+    final_time : float
+        The output variables value is collected at t=final_time and returned by
+        FMUFunction.
 
     kind : str, one of "ME" (model exchange) or "CS" (co-simulation)
         Select a kind of FMU if both are available.

--- a/otfmi/otfmi.py
+++ b/otfmi/otfmi.py
@@ -456,10 +456,9 @@ class OpenTURNSFMUPointToFieldFunction(ot.OpenTURNSPythonPointToFieldFunction):
 
         self._set_inputs_fmu(inputs_fmu)
         self._set_outputs_fmu(outputs_fmu)
-        self.mesh = mesh
 
         super(OpenTURNSFMUPointToFieldFunction, self).__init__(len
-            (self.inputs_fmu), self.mesh,
+            (self.inputs_fmu), mesh,
                                                                len(self.outputs_fmu))
         self._set_inputs(inputs)
         self._set_outputs(outputs)
@@ -583,12 +582,13 @@ class OpenTURNSFMUPointToFieldFunction(ot.OpenTURNSPythonPointToFieldFunction):
         """Raise an error if the mesh is not comprised between the start and
         final simulation time.
         """
-        mesh_min = self.mesh.getValues()[0]
+        mesh = self.getOutputMesh()
+        mesh_min = mesh.getVertices().getMin()[0]
         assert mesh_min >= self.start_time, """The mesh start time must be >= to FMU start time.\n
             To set the FMU start time, use the argument *start_time* in
             FMUPointToFieldFunction constructor."""
 
-        mesh_max = self.mesh.getValues()[-1]
+        mesh_max = mesh.getVertices().getMax()[0]
         assert mesh_max <= self.final_time, """The mesh final time must be >= to FMU final time.\n
             To set the FMU final time, use the argument final_time in
             FMUPointToFieldFunction constructor."""

--- a/test/test_FMUPointToFieldFunction.py
+++ b/test/test_FMUPointToFieldFunction.py
@@ -59,7 +59,7 @@ class TestEpid(unittest.TestCase):
         """Check if incoherent start time raises an error
         """
         self.assertRaises(AssertionError,
-            otfmi.OpenTURNSFMUPointToFieldFunction,
+            otfmi.FMUPointToFieldFunction,
             self.mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],
@@ -69,13 +69,13 @@ class TestEpid(unittest.TestCase):
     def test_start_time(self):
         """Check if start times are taken into account.
         """
-        model_fmu_1 = otfmi.OpenTURNSFMUPointToFieldFunction(
+        model_fmu_1 = otfmi.FMUPointToFieldFunction(
             self.mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],
             outputs_fmu=['infected'],
             start_time=0)
-        model_fmu_2 = otfmi.OpenTURNSFMUPointToFieldFunction(
+        model_fmu_2 = otfmi.FMUPointToFieldFunction(
             self.mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],
@@ -89,7 +89,7 @@ class TestEpid(unittest.TestCase):
         """Check if incoherent final time raises an error.
         """
         self.assertRaises(AssertionError,
-            otfmi.OpenTURNSFMUPointToFieldFunction,
+            otfmi.FMUPointToFieldFunction,
             self.mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],

--- a/test/test_OpenTURNSFMUPointToFieldFunction.py
+++ b/test/test_OpenTURNSFMUPointToFieldFunction.py
@@ -58,13 +58,13 @@ class TestEpid(unittest.TestCase):
     def test_start_time_coherence(self):
         """Check if incoherent start time raises an error
         """
-        model_fmu = otfmi.OpenTURNSFMUPointToFieldFunction(
+        self.assertRaises(AssertionError,
+            otfmi.OpenTURNSFMUPointToFieldFunction,
             self.mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],
             outputs_fmu=['infected'],
             start_time=10)
-        self.assertRaises(AssertionError, model_fmu._exec, input_value)
 
     def test_start_time(self):
         """Check if start times are taken into account.
@@ -88,13 +88,13 @@ class TestEpid(unittest.TestCase):
     def test_final_time_coherence(self):
         """Check if incoherent final time raises an error.
         """
-        model_fmu = otfmi.OpenTURNSFMUPointToFieldFunction(
+        self.assertRaises(AssertionError,
+            otfmi.OpenTURNSFMUPointToFieldFunction,
             self.mesh,
             self.path_fmu,
             inputs_fmu=['infection_rate', 'healing_rate'],
             outputs_fmu=['infected'],
             final_time=10)
-        self.assertRaises(AssertionError, model_fmu._exec, input_value)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_epid.py
+++ b/test/test_epid.py
@@ -18,19 +18,21 @@ dict_platform = {("Linux", "64bit"):"linux64",
 input_value = [0.007, 0.02]
 
 
-def simulate_with_pyfmi(path_fmu):
-    """Return the last simulation times.
+def simulate_with_pyfmi(path_fmu, final_time=None):
+    """Return the output on the 5 last simulation times.
     By default, pyfmi simulation output counts 500 steps.
     """
     check_model = pyfmi.load_fmu(path_fmu)
     check_model.set(["infection_rate", "healing_rate"], input_value)
-    check_result = check_model.simulate()
+    if final_time is not None:
+        check_result = check_model.simulate(final_time=final_time)
+    else:
+        check_result = check_model.simulate()
     # Get the infected column
     list_variable = list(check_model.get_model_variables().keys())
     infected_column = list_variable.index("infected") + 1
     # +1 stands for time column, inserted as first in the data matrix
     list_last_infected_value = check_result.data_matrix[infected_column][-5:-1]
-    print(list_last_infected_value)
     return list_last_infected_value
 
 
@@ -61,6 +63,12 @@ class TestEpid(unittest.TestCase):
         """
         pass
 
+    def test_final_value(self):
+        """Check reproducibility of the final value.
+        """
+        y = self.model_fmu(input_value)
+        assert m.fabs(y[0] - 265.68) < 1e-2, "wrong value"
+
     def test_fmufunction_interpolation(self):
         """Check that FMUFunction returns a point corresponding to Pyfmi's
         interpolated output.
@@ -70,6 +78,30 @@ class TestEpid(unittest.TestCase):
         assert y[0] < max(list_last_infected_value)
         assert y[0] > min(list_last_infected_value)
 
+    def test_final_time(self):
+        """Check that specified final time is taken into account.
+        """
+        final_time = 2.
+        model_fmu_1 = otfmi.FMUFunction(
+            self.path_fmu,
+            inputs_fmu=["infection_rate", "healing_rate"],
+            outputs_fmu=["infected"],
+            final_time=final_time)
+        list_last_infected_value = simulate_with_pyfmi(self.path_fmu,
+            final_time=final_time)
+        y = model_fmu_1(input_value)
+        assert y[0] < max(list_last_infected_value)
+        assert y[0] > min(list_last_infected_value)
+
+    def test_keyword(self):
+        """Check that specifying final time at simulation raises a Warning.
+        """
+        lowlevel_model_fmu = otfmi.OpenTURNSFMUFunction(
+            self.path_fmu,
+            inputs_fmu=["infection_rate", "healing_rate"],
+            outputs_fmu=["infected"])
+        self.assertRaises(Warning, lowlevel_model_fmu._exec, input_value,
+            final_time=50.)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Enable the user to set start and final time for the FMU simulation time in *FMUPointToFieldFunction* and *OpenTURNSFMUPointToFieldFunction*

Raise an error if the mesh start or stop time are outside the simulation start and stop time.